### PR TITLE
Update installer and docs with information about packed (portable) builds

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -1,5 +1,40 @@
 #!/usr/bin/env sh
 
+auto_detect_install_type() {
+    case "$(uname -s)" in
+        Linux)
+            # Detect default path for glibc interpreter path
+            case "$(uname -m)" in
+                x86_64)
+                    default_interp_path="/lib64/ld-linux-x86-64.so.2"
+                    ;;
+                aarch64)
+                    default_interp_path="/lib/ld-linux-aarch64.so.1"
+                    ;;
+                *)
+                    echo "Could not determine GNU interpreter path for architecture $(uname -m)" >&2
+                    exit 1
+                    ;;
+            esac
+
+            interp_version="$("$default_interp_path" --version 2>&1 || true)"
+
+            if [ "$(uname -o)" != "GNU/Linux" ]; then
+                echo "Detected non-GNU platform, installing packed build" >&2
+                echo "packed"
+            elif ! echo "$interp_version" | grep -qi "GLIBC"; then
+                echo "Detected non-GNU platform, installing packed build" >&2
+                echo "packed"
+            else
+                echo "bin"
+            fi
+
+            ;;
+        *)
+            echo "bin"
+    esac
+}
+
 # Wrap the installation in a function so it only runs once the
 # entire script is downloaded
 install_brioche() {
@@ -16,27 +51,44 @@ install_brioche() {
     fi
 
     # The directory where Brioche gets installed
+    install_dir="${BRIOCHE_INSTALL_DIR:-$HOME/.local/bin}"
 
-    # Get the URL based on the kernel and architecture
-    case "$(uname -s)" in
-        Linux)
-            case "$(uname -m)" in
-                x86_64)
-                    brioche_url="https://releases.brioche.dev/v0.1.4/x86_64-linux/brioche"
-                    checksum="90a1366eabf63e04c559b77436b315736da8b73ce5b8e3b30eb5ac69b7e3c494"
-                    ;;
-                *)
-                    echo "Sorry, Brioche isn't currently supported on your architecture"
-                    echo "  Detected architecture: $(uname -m)"
-                    exit 1
-                    ;;
-            esac
+    # The directory where to unpack the installation, when using a packed build
+    unpack_dir="${BRIOCHE_INSTALL_UNPACK_DIR:-$HOME/.local/libexec/brioche}"
+
+    # Whether to install a packed build or a standalone binary
+    install_type="${BRIOCHE_INSTALL_TYPE:-auto}"
+
+    # Auto-detect installation type
+    if [ "$install_type" = "auto" ]; then
+        install_type="$(auto_detect_install_type)"
+    fi
+
+    # Validate installation type
+    case "$install_type" in
+        bin | packed)
             ;;
         *)
-            echo "Sorry, Brioche isn't currently supported on your operating system"
-    install_dir="${BRIOCHE_INSTALL_DIR:-$HOME/.local/bin}"
-            echo "  Detected kernel: $(uname -s)"
+            echo "Unsupported installation type: $install_type" >&2
             exit 1
+            ;;
+    esac
+
+    # Get the URL based on the kernel, architecture, and installation type
+    case "$(uname -sm) $install_type" in
+        "Linux x86_64 bin")
+            brioche_url="https://releases.brioche.dev/v0.1.4/x86_64-linux/brioche"
+            checksum="90a1366eabf63e04c559b77436b315736da8b73ce5b8e3b30eb5ac69b7e3c494"
+            ;;
+        "Linux x86_64 packed")
+            brioche_url="https://releases.brioche.dev/v0.1.4/brioche-packed/x86_64-linux/brioche-packed-x86_64-linux.tar.gz"
+            checksum="bc9aea0416b74f163bd801e87beb8b11eb99a5336700829eb8319ba9b612e06f"
+            ;;
+        *)
+            echo "Sorry, Brioche isn't currently supported on your platform"
+            echo "  Detected kernel: $(uname -s)"
+            echo "  Detected architecture: $(uname -m)"
+            echo "  Installation type: $install_type"
             ;;
     esac
 
@@ -49,21 +101,50 @@ install_brioche() {
     echo "  Checksum: $checksum"
     echo
 
-    # Download to a temporary path first
-    echo "Downloading to \`$brioche_temp/brioche\`..."
-    curl --proto '=https' --tlsv1.2 -fL "$brioche_url" -o "$brioche_temp/brioche"
+    # Download the file to a temporary path
+    temp_download="$brioche_temp/brioche-dl.tmp"
+    echo "Downloading to \`$temp_download\`..."
+    curl --proto '=https' --tlsv1.2 -fL "$brioche_url" -o "$temp_download"
     echo
 
     # Validate the checksum
     echo "Validating checksum..."
-    echo "$checksum  $brioche_temp/brioche" | sha256sum -c -
+    echo "$checksum  $temp_download" | sha256sum -c -
     echo
 
-    # Install to the target directory
-    echo "Installing to \`$install_dir/brioche\`..."
-    mkdir -p "$install_dir"
-    chmod +x "$brioche_temp/brioche"
-    mv "$brioche_temp/brioche" "$install_dir/brioche"
+    case "$install_type" in
+        bin)
+            # Install to the target directory
+            echo "Installing to \`$install_dir/brioche\`..."
+            mkdir -p "$install_dir"
+            chmod +x "$temp_download"
+            mv "$temp_download" "$install_dir/brioche"
+            ;;
+        packed)
+            echo "******************************************************************************" >&2
+            echo "** Heads up! Packed builds are experimental and don't support all features! **" >&2
+            echo "******************************************************************************" >&2
+
+            echo
+
+            # Unpack tarfile into the unpack directory
+            echo "Unpacking to \`$unpack_dir\`..."
+            rm -rf "$unpack_dir"
+            mkdir -p "$unpack_dir"
+            tar -xzf "$brioche_temp/brioche-dl.tmp" --strip-components=1 -C "$unpack_dir"
+
+            # Add a symlink in the install directory to the binary
+            # within the unpacked dir
+            symlink_target="$unpack_dir/bin/brioche"
+            echo "Adding symlink \`$install_dir/brioche\` -> \`$symlink_target\`..."
+            mkdir -p "$install_dir"
+            ln -sf "$symlink_target" "$install_dir/brioche"
+            ;;
+        *)
+            echo "Unexpected installation type: $install_type" >&2
+            exit 1
+            ;;
+    esac
 
     echo "Installation complete!"
 

--- a/public/install.sh
+++ b/public/install.sh
@@ -41,7 +41,7 @@ install_brioche() {
     esac
 
     # Create a temporary directory
-    brioche_temp="$(mktemp -d -t brioche-XXXX)"
+    brioche_temp="$(mktemp -d -t brioche-XXXXXX)"
     trap 'rm -rf -- "$brioche_temp"' EXIT
 
     echo "Downloading Brioche..."

--- a/public/install.sh
+++ b/public/install.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # Wrap the installation in a function so it only runs once the
 # entire script is downloaded
-function install_brioche() {
-    set -euo pipefail
+install_brioche() {
+    set -eu
 
     # Validate $HOME is set to a valid directory
     if [ -z "$HOME" ]; then
@@ -18,9 +18,9 @@ function install_brioche() {
     # The directory where Brioche gets installed
     install_dir="$HOME/.local/bin"
 
-    # Get the URL based on the OS and architecture
-    case "$OSTYPE" in
-        linux*)
+    # Get the URL based on the kernel and architecture
+    case "$(uname -s)" in
+        Linux)
             case "$(uname -m)" in
                 x86_64)
                     brioche_url="https://releases.brioche.dev/v0.1.4/x86_64-linux/brioche"
@@ -35,7 +35,7 @@ function install_brioche() {
             ;;
         *)
             echo "Sorry, Brioche isn't currently supported on your operating system"
-            echo "  Detected OS: $OSTYPE"
+            echo "  Detected kernel: $(uname -s)"
             exit 1
             ;;
     esac

--- a/public/install.sh
+++ b/public/install.sh
@@ -16,7 +16,6 @@ install_brioche() {
     fi
 
     # The directory where Brioche gets installed
-    install_dir="$HOME/.local/bin"
 
     # Get the URL based on the kernel and architecture
     case "$(uname -s)" in
@@ -35,6 +34,7 @@ install_brioche() {
             ;;
         *)
             echo "Sorry, Brioche isn't currently supported on your operating system"
+    install_dir="${BRIOCHE_INSTALL_DIR:-$HOME/.local/bin}"
             echo "  Detected kernel: $(uname -s)"
             exit 1
             ;;

--- a/src/content/docs/docs/getting-started.md
+++ b/src/content/docs/docs/getting-started.md
@@ -44,7 +44,7 @@ There are lots and lots of different package managers to choose from, and all of
 Run the following command to install Brioche:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSfL 'https://brioche.dev/install.sh' | bash
+curl --proto '=https' --tlsv1.2 -sSfL 'https://brioche.dev/install.sh' | sh
 ```
 
 For the best experience, [configuring your editor with Brioche support](/docs/installation#editor-support) is **strongly recommended!** Also see [Installation](/docs/installation) for more installation options and details.

--- a/src/content/docs/docs/installation.md
+++ b/src/content/docs/docs/installation.md
@@ -26,11 +26,22 @@ The installer script supports passing extra environment variables to customize t
 
 Rather than running the installation script, you can also manually install Brioche by downloading the latest release under the ["Releases"](https://github.com/brioche-dev/brioche/releases) section of Brioche's GitHub repo.
 
-**Linux (x86-64)**
+**Linux**
 
-1. Download the latest release binary for your architecture from the ["Releases"](https://github.com/brioche-dev/brioche/releases) page.
+> These instructions work for systems that use glibc, which includes most distributions. For Linux distributions that don't use glibc, such as Alpine Linux or NixOS, see the "**Linux (portable)**" section below.
+
+1. Download the latest release binary for your architecture from the ["Releases"](https://github.com/brioche-dev/brioche/releases) page, e.g. `brioche-x86_64-linux`
 2. Place the binary in your desired installation directory, such as `~/.local/bin`. Brioche can be run from any directory, but it should be a directory in your `$PATH`.
 3. Make the binary executable using `chmod`: `chmod +x ~/.local/bin/brioche`
+
+**Linux (portable)**
+
+> **Note**: Portable builds are still considered experimental, and may not support all features of Brioche yet! Non-portable builds are currently recommended unless your system doesn't use glibc.
+
+1. Download the latest release tar file named `brioche-packed-*` for your architecture from the ["Releases"](https://github.com/brioche-dev/brioche/releases) page, e.g. `brioche-packed-x86_64-linux.tar.gz`
+2. Create a new directory to contain the unpacked tar file: `mkdir -p ~/.local/libexec/brioche`
+3. Extract the tar file using into the directory: `tar -xzf brioche-packed-x86_64-linux.tar.gz --strip-components=1 -C ~/.local/libexec/brioche`
+4. Add a symlink for `bin/brioche` from the unpacked directory into a folder in your `$PATH`: `ln -s ~/.local/libexec/brioche/bin/brioche ~/.local/bin/brioche`
 
 ## Editor support
 

--- a/src/content/docs/docs/installation.md
+++ b/src/content/docs/docs/installation.md
@@ -9,7 +9,7 @@ Brioche is distributed as a portable executable that can be dropped in and run e
 **Linux (x86-64)**
 
 ```bash
-curl --proto '=https' --tlsv1.2 -sSfL 'https://brioche.dev/install.sh' | bash
+curl --proto '=https' --tlsv1.2 -sSfL 'https://brioche.dev/install.sh' | sh
 ```
 
 This script will install Brioche under `~/.local/bin`, which is commonly included by default in the `$PATH` for your shell.

--- a/src/content/docs/docs/installation.md
+++ b/src/content/docs/docs/installation.md
@@ -14,6 +14,14 @@ curl --proto '=https' --tlsv1.2 -sSfL 'https://brioche.dev/install.sh' | sh
 
 This script will install Brioche under `~/.local/bin`, which is commonly included by default in the `$PATH` for your shell.
 
+### Installation options
+
+The installer script supports passing extra environment variables to customize the installation. You can either set each of these environment variables before running the installer (e.g. `export BRIOCHE_INSTALL_TYPE=bin`), or prepend it before the `sh` command (e.g. `curl ... | BRIOCHE_INSTALL_TYPE=bin sh`).
+
+- `BRIOCHE_INSTALL_DIR`: The directory to place the final Brioche binary. This directory should ideally be in your `$PATH` and will get created if it doesn't exist. Defaults to `$HOME/.local/bin`.
+- `BRIOCHE_INSTALL_TYPE`: The type of installation to use. Options are `auto` (default), `packed` for portable builds, or `bin` for standalone builds.
+- `BRIOCHE_INSTALL_UNPACK_DIR`: For packed installations, the directory where the packed build will be unpacked to. Defaults to `$HOME/.local/libexec/brioche`.
+
 ## Manual installation
 
 Rather than running the installation script, you can also manually install Brioche by downloading the latest release under the ["Releases"](https://github.com/brioche-dev/brioche/releases) section of Brioche's GitHub repo.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,7 +25,7 @@ const codeExampleSnippet = indoc`
 `;
 
 const installSnippet = indoc`
-  curl --proto '=https' --tlsv1.2 -sSfL 'https://brioche.dev/install.sh' | bash
+  curl --proto '=https' --tlsv1.2 -sSfL 'https://brioche.dev/install.sh' | sh
 `;
 
 const helloWorldSnippet = indoc`


### PR DESCRIPTION
This PR updates the `install.sh` script to support installing packed builds (i.e. portable builds on Linux), along with a few miscellaneous changes. Plus, it updates the installation docs for these changes.

Here's what changed

- Update `install.sh` to use standard POSIX sh syntax
  - Update docs to use `curl ... | sh` in examples (rather than `curl ... | bash`)
- Update `install.sh` to support using `brioche-packed-*` builds during installation. We try to detect if this is needed by checking `uname -o` and the output of running `ld-linux.so`-- if they don't look like the values you get on glibc systems, then we do a packed installation.
- Update `install.sh` to take a few options with env vars
  - `$BRIOCHE_INSTALL_DIR` - The directory where the final Brioche binary goes (defaults to `~/.local/bin`)
  - `$BRIOCHE_INSTALL_TYPE` - Used to control the installation type. Can be `auto` (default), `packed`, or `bin`
  - `$BRIOCHE_INSTALL_UNPACK_DIR` - The directory where the packed tarfile get unpacked before getting symlinked into the install dir (defaults to `~/.local/libexec/brioche`)
- Update docs with instructions for setting `install.sh` options
- Update docs with instructions for manually installing packed builds