### PR TITLE
Update install script

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -22,7 +22,7 @@ auto_detect_install_type() {
             if [ "$(uname -o)" != "GNU/Linux" ]; then
                 echo "Detected non-GNU platform, installing packed build" >&2
                 echo "packed"
-            elif ! echo "$interp_version" | grep -qi "GLIBC"; then
+            elif ! echo "$interp_version" | grep -qiE 'glibc|gnu libc'; then
                 echo "Detected non-GNU platform, installing packed build" >&2
                 echo "packed"
             else

--- a/public/install.sh
+++ b/public/install.sh
@@ -89,6 +89,7 @@ install_brioche() {
             echo "  Detected kernel: $(uname -s)"
             echo "  Detected architecture: $(uname -m)"
             echo "  Installation type: $install_type"
+            exit 1
             ;;
     esac
 


### PR DESCRIPTION
This PR aims to resolve two issues I encountered while testing [`lima`](https://github.com/lima-vm/lima) in an aarch64 environment.

### Improvements to platform detection:

* Updated the `auto_detect_install_type` function to recognize both "glibc" and "gnu libc" in the interpreter version check, improving compatibility with various libc implementations, and more particularly with Fedora based distribution:

```bash
# Without
> if [ "$(uname -o)" != "GNU/Linux" ]; then
                echo "Detected non-GNU platform, installing packed build" >&2
                echo "packed"
            elif ! echo "$interp_version" | grep -qi "GLIBC"; then
                echo "Detected non-GNU platform, installing packed build" >&2
                echo "packed"
            else
                echo "bin"
            fi
Detected non-GNU platform, installing packed build
packed

# Output of 'interp_version' on Fedora
ld.so (GNU libc) stable release version 2.40. Copyright (C) 2024 Free Software Foundation, Inc. This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

# With
> if [ "$(uname -o)" != "GNU/Linux" ]; then
                echo "Detected non-GNU platform, installing packed build" >&2
                echo "packed"
            elif ! echo "$interp_version" | grep -qiE 'glibc|gnu libc'; then
                echo "Detected non-GNU platform, installing packed build" >&2
                echo "packed"
            else
                echo "bin"
            fi
bin
```

### Enhanced error handling:

* Added an explicit `exit 1` statement in the `install_brioche` function to ensure the script terminates with a failure status when an unsupported installation type is encountered.

Otherwise we are getting an error, since the script continues to run normally.

```bash
> curl --proto '=https' --tlsv1.2 -sSfL 'https://brioche.dev/install.sh' | sh
Detected non-GNU platform, installing packed build
Sorry, Brioche isn't currently supported on your platform
  Detected kernel: Linux
  Detected architecture: aarch64
  Installation type: packed
Downloading Brioche...
main: line 100: brioche_url: unbound variable
```