### PR TITLE
ci: add GitHub Actions check update to Dependabot Config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "17:00"
+      timezone: "America/Los_Angeles"
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
This PR updates the `.github/dependabot.yml` configuration to also check update of GitHub Actions.